### PR TITLE
Updated font awesome dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "ui-router": "~0.2.13",
     "bootstrap-btn-outline-rounded": "~0.0.3",
     "angular-animate": "~1.3.15",
-    "fontawesome": "~4.3.0",
+    "components-font-awesome": "~4.3.0",
     "angular-snap": "~1.8.1"
   },
   "devDependencies": {


### PR DESCRIPTION
"fontawesome" repo only enlist .less and .scss file as main in bower.json, this causes gulp's wiredep task to not include font-awesome in index.html.
